### PR TITLE
Pin reportlab to last stable version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,12 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# Idea
+.idea/
+
+# Mac Nonsense
+.DS_Store
+
+# PyENV
+.python-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ html5lib==1.0b10
 httplib2==0.7.6
 nose==1.3.3
 pyPdf2==1.26
-reportlab>=3.0
+reportlab>=3.0, <=3.6.6
 six
 Sphinx==1.4.8
 sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
Capped ReportLab at 3.6.6 for now

Also added some stuff to .gitignore incase more changes are made in the future. 