### PR TITLE
Bump reportlab for py3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Pillow>=2.0.0
 coverage
-html5lib==1.0b10
+html5lib==1.1
 httplib2==0.7.6
-nose==1.3.3
+nose-py3==1.6.3
 pyPdf2==1.26
-reportlab>=3.0, <=3.6.6
+reportlab>=3.0, <=3.6.13
 six
 Sphinx==1.4.8
 sphinx-rtd-theme==0.1.9

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     maintainer_email="use-github@doit.com",
     url="http://github.com/xhtml2pdf/xhtml2pdf",
     keywords="PDF, HTML, XHTML, XML, CSS",
-    install_requires=["html5lib==1.0b10", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0, <=3.6.6", "six"],
+    install_requires=["html5lib==1.1", "httplib2", "pyPdf2", "Pillow", "reportlab>=3.0, <=3.6.13", "six"],
     setup_requires=["nose>=1.0"],
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/xhtml2pdf/xhtml2pdf_reportlab.py
+++ b/xhtml2pdf/xhtml2pdf_reportlab.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 from hashlib import md5
+from html import escape as html_escape
 from reportlab.lib.enums import TA_RIGHT
 from reportlab.lib.styles import ParagraphStyle
-from reportlab.lib.utils import flatten, open_for_read, getStringIO, \
+from reportlab.lib.utils import flatten, open_for_read, \
     LazyImageReader, haveImages
 from reportlab.platypus.doctemplate import BaseDocTemplate, PageTemplate, IndexingFlowable
 from reportlab.platypus.flowables import Flowable, CondPageBreak, \
@@ -29,6 +30,7 @@ from xhtml2pdf.util import getUID, getBorderStyle
 
 import six
 import sys
+from io import StringIO
 
 import cgi
 import copy
@@ -121,7 +123,7 @@ class PmlBaseDoc(BaseDocTemplate):
         if getattr(flowable, "outline", False):
             self.notify('TOCEntry', (
                 flowable.outlineLevel,
-                cgi.escape(copy.deepcopy(flowable.text), 1),
+                html_escape(copy.deepcopy(flowable.text), 1),
                 self.page))
 
     def handle_nextPageTemplate(self, pt):
@@ -338,7 +340,7 @@ class PmlImageReader(object):  # TODO We need a factory here, returning either a
                             register_reset(self._cache.clear)
 
                         data = self._cache.setdefault(md5(data).digest(), data)
-                    self.fp = getStringIO(data)
+                    self.fp = StringIO(data)
                 elif imageReaderFlags == - 1 and isinstance(fileName, six.text_type):
                     #try Ralf Schmitt's re-opening technique of avoiding too many open files
                     self.fp.close()


### PR DESCRIPTION
Bump Reportlab version to 3.6.13 (Highest version of 3.6) for use in Python 3.11 (3.6.6 relays on c libs that python moved in 3.11)

Needed to bump to nose-py3 to get tests running again.

Needed HTML5Lib bump to support some parsing changes

Needed to move to StringIO from `getStringIO`
Needed to move to `html.escape` from `cgi.escape` 

Test pass locally 

It appears ARM is the only APP using this repo so Multi python version support will not be supported. 